### PR TITLE
Fixed joint angle inversion method and updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 lynxmotion_ssc32
 ================
 
-ROS driver for the Lynxmotion SSC-32 servo controller.
+ROS driver for the Lynxmotion SSC-32 and SSC-32U servo controller.

--- a/include/lynxmotion_ssc32/ssc32_driver.h
+++ b/include/lynxmotion_ssc32/ssc32_driver.h
@@ -84,6 +84,7 @@ class SSC32Driver
 		int baud;
 		bool publish_joint_states;
 		double range_scale;
+		double scale;
 		std::vector<Controller*> controllers;
 		std::map<std::string, Controller*> controllers_map;
 		std::map<std::string, Joint*> joints_map;

--- a/src/ssc32_driver.cpp
+++ b/src/ssc32_driver.cpp
@@ -415,7 +415,7 @@ void SSC32Driver::jointCallback( const ros::MessageEvent<trajectory_msgs::JointT
 
 	bool invalid = false;
 
-	const double scale = 2000.0 / M_PI;
+	const double scale = range_scale * 2000.0 / M_PI;
 
 	for( unsigned int i = 0; i < msg->joint_names.size( ) && !invalid; i++ )
 	{
@@ -424,15 +424,14 @@ void SSC32Driver::jointCallback( const ros::MessageEvent<trajectory_msgs::JointT
 			Joint *joint = joints_map[msg->joint_names[i]];
 
 			double angle = msg->points[0].positions[i];
-			if(joint->properties.invert)
-				angle *= -1.0;
 
 			// Validate the commanded position (angle)
 			if( angle >= joint->properties.min_angle && angle <= joint->properties.max_angle )
 			{
 				cmd[i].ch = joint->properties.channel;
-				cmd[i].pw = ( unsigned int )( angle * scale + joint->properties.offset_angle + 1500 + 0.5 );
-
+				cmd[i].pw = ( unsigned int )( scale * ( angle - joint->properties.offset_angle ) + 1500 + 0.5 );
+				if( joint->properties.invert )
+					cmd[i].pw = 3000 - cmd[i].pw;
 				if( cmd[i].pw < 500 )
 					cmd[i].pw = 500;
 				else if( cmd[i].pw > 2500 )

--- a/src/ssc32_driver.cpp
+++ b/src/ssc32_driver.cpp
@@ -362,9 +362,9 @@ void SSC32Driver::publishJointStates( )
 					pw = 3000 - pw;
 
 				//ROS_DEBUG( "Pulse width for joint [%s] is %d", controllers[i]->joints[j]->name.c_str( ), pw );
-
+				const double scale = range_scale * 2000.0 / M_PI;
 				//double angle = M_PI_2 * ( ( double )pw - controllers[i]->joints[j]->properties.default_angle ) / 1000.0;
-				double angle = M_PI * ( ( double ) pw - 1500.0 ) / 2000.0 + controllers[i]->joints[j]->properties.offset_angle;
+				double angle = ( ( double ) pw - 1500.0 ) / scale + controllers[i]->joints[j]->properties.offset_angle;
 
 				//ROS_DEBUG( "Angle calculated for joint [%s] is %f", controllers[i]->joints[j]->name.c_str( ), angle );
 

--- a/src/ssc32_driver.cpp
+++ b/src/ssc32_driver.cpp
@@ -24,6 +24,7 @@ SSC32Driver::SSC32Driver( ros::NodeHandle &nh ) :
 
 	if ( range_scale > 1 || range_scale <= 0 )
 		range_scale = 1.0;
+	scale = range_scale * 2000.0 / M_PI;
 
 	// Parse joints ros param
 	XmlRpc::XmlRpcValue joints_list;
@@ -191,7 +192,6 @@ SSC32Driver::~SSC32Driver( )
 bool SSC32Driver::init( )
 {
 	SSC32::ServoCommand *cmd;
-	const double scale = range_scale * 2000.0 / M_PI;
 	bool success = true;
 
 	// Initialize each controller
@@ -362,7 +362,6 @@ void SSC32Driver::publishJointStates( )
 					pw = 3000 - pw;
 
 				//ROS_DEBUG( "Pulse width for joint [%s] is %d", controllers[i]->joints[j]->name.c_str( ), pw );
-				const double scale = range_scale * 2000.0 / M_PI;
 				//double angle = M_PI_2 * ( ( double )pw - controllers[i]->joints[j]->properties.default_angle ) / 1000.0;
 				double angle = ( ( double ) pw - 1500.0 ) / scale + controllers[i]->joints[j]->properties.offset_angle;
 
@@ -415,7 +414,6 @@ void SSC32Driver::jointCallback( const ros::MessageEvent<trajectory_msgs::JointT
 
 	bool invalid = false;
 
-	const double scale = range_scale * 2000.0 / M_PI;
 
 	for( unsigned int i = 0; i < msg->joint_names.size( ) && !invalid; i++ )
 	{


### PR DESCRIPTION
The logic behind the inverting the joint angles was different between the initialization and joint callback methods. At initialization, the offset was removed and the angle is then inverted.   However,  the joint callback inverts the angle and then adds the angle offset.   I used the same logic as the initialization for the joint callback. Also, I updated the README to include the newer version of this servo driver, the ssc-32u which I am currently using.